### PR TITLE
[postgresdb] engine_version variable

### DIFF
--- a/postgresdb/main.tf
+++ b/postgresdb/main.tf
@@ -19,7 +19,7 @@ resource "aws_db_instance" "database" {
   allocated_storage         = 20
   storage_type              = "gp2"
   engine                    = "postgres"
-  engine_version            = "10.5"
+  engine_version            = "${var.db_engine_version}"
   instance_class            = "db.t2.micro"
   deletion_protection       = "${var.deletion_protection}"
   identifier                = "${var.namespace}"

--- a/postgresdb/variables.tf
+++ b/postgresdb/variables.tf
@@ -2,6 +2,11 @@ variable "namespace" {
   description = "Name to help identify database resources, e.g. app-production."
 }
 
+variable "db_engine_version" {
+  description = "Engine version for the database."
+  default     = "10.6"
+}
+
 variable "db_name" {
   description = "Name of the RDS database to create for the application."
 }


### PR DESCRIPTION
RDS will upgrade the database within the maintenance window. Once you're upgraded, terraform will try to downgrade, which fails. So we need a variable so that we can update the engine after RDS upgrades.