### PR TITLE
Update s3-cloudfront-website module to use non-Github source

### DIFF
--- a/s3_cloudfront_website/main.tf
+++ b/s3_cloudfront_website/main.tf
@@ -7,7 +7,7 @@ provider "aws" {
 }
 
 module "site" {
-  source  = "github.com/riboseinc/terraform-aws-s3-cloudfront-website"
+  source  = "riboseinc/s3-cloudfront-website/aws"
   version = "1.0.1"
 
   fqdn                = "${var.host}.${var.zone}"


### PR DESCRIPTION
The version lock, under Terraform 0.12, doesn't work when the source is
Github.

Error: Invalid version constraint

Cannot apply a version constraint to module "site" (at
.terraform/modules/openoakland_org.site/s3_cloudfront_website/main.tf:9)
because it has a non Registry URL.