### PR TITLE
Allow "site" module to specify alias domains

### DIFF
--- a/s3_cloudfront_website/main.tf
+++ b/s3_cloudfront_website/main.tf
@@ -10,6 +10,7 @@ module "site" {
   source = "github.com/riboseinc/terraform-aws-s3-cloudfront-website?ref=8b040cc6"
 
   fqdn                = "${var.host}.${var.zone}"
+  aliases             = var.aliases
   ssl_certificate_arn = aws_acm_certificate_validation.cert.certificate_arn
   allowed_ips         = var.allowed_ips
 
@@ -28,6 +29,7 @@ resource "aws_acm_certificate" "cert" {
   provider          = aws.cloudfront
   domain_name       = "${var.host}.${var.zone}"
   validation_method = "DNS"
+  subject_alternative_names = var.aliases
 }
 
 resource "aws_route53_record" "cert_validation" {
@@ -42,7 +44,7 @@ resource "aws_route53_record" "cert_validation" {
 resource "aws_acm_certificate_validation" "cert" {
   provider                = aws.cloudfront
   certificate_arn         = aws_acm_certificate.cert.arn
-  validation_record_fqdns = [aws_route53_record.cert_validation.fqdn]
+  validation_record_fqdns = aws_acm_certificate.cert.domain_validation_options.*.resource_record_name
 }
 
 # Route 53 record for the static site

--- a/s3_cloudfront_website/variables.tf
+++ b/s3_cloudfront_website/variables.tf
@@ -7,6 +7,16 @@ variable "zone" {
   default     = "aws.openoakland.org"
 }
 
+# NOTE: These aliases will be added as Subject Alternate Names (SAN's) for the
+# TLS certificate that is created for the site. You will need to create the DNS
+# records that the Amazon console tells you to during the initial `terraform
+# apply`.
+variable "aliases" {
+  description = "The other domain names at which the site is accessible."
+  type        = list(string)
+  default     = []
+}
+
 # Allowed IPs that can directly access the S3 bucket
 variable "allowed_ips" {
   type    = list(string)


### PR DESCRIPTION
There is a bit of assumption baked into this module about the fact that
the site is accessible at a URL in the format of
beta.aws.openoakland.org (i.e. a Route53 zone). By adding an "aliases"
option, we can tell Cloudfront that our site should also be accessible
via other domains, namely our preferred "openoakland.org".

The caveat here is that for the TLS certificate, Amazon makes us
validate all aliases. We can automatically validate the primary fqdn
since it's in Route53, but not any aliases. So, when running the
terraform for the first time, the user will have to manually create the
other domains (in Namecheap or wherever else) during the validation
step.